### PR TITLE
fix the mistake for the time limit for loading classes via Soot

### DIFF
--- a/src/jdd/config/SootConfig.java
+++ b/src/jdd/config/SootConfig.java
@@ -106,7 +106,7 @@ public class SootConfig {
                         protected void timeoutHandler(){
                             log.error("将类" + cl + "导入到soot过程中超时，跳过处理");
                         }
-                    }).run(10);
+                    }).run(100);
 
                 }catch (Exception e){
                     log.error("加载类" + cl + "过程中出错：" + e.getMessage());


### PR DESCRIPTION
The original code contains an inconsistency at Lines 90 and 109.

https://github.com/fdu-sec/JDD/blob/40da2d0141cfd43bb2bf676bee600b50e5ac2131/src/jdd/config/SootConfig.java#L90

and 

https://github.com/fdu-sec/JDD/blob/40da2d0141cfd43bb2bf676bee600b50e5ac2131/src/jdd/config/SootConfig.java#L109

